### PR TITLE
Add Data-Shield Blocklist plugin

### DIFF
--- a/apps/fr.madyanne.zoraxy.datashield-blocklist.json
+++ b/apps/fr.madyanne.zoraxy.datashield-blocklist.json
@@ -1,0 +1,6 @@
+{
+  "repo_url": "https://github.com/kianby/zoraxy-datashield-blocklist",
+  "author": "Yax",
+  "contact": "https://github.com/kianby",
+  "min_zoraxy_version": "3.2.0"
+}


### PR DESCRIPTION
## New plugin: Data-Shield Blocklist

Adds the [Data-Shield Blocklist](https://github.com/kianby/zoraxy-datashield-blocklist) plugin to the official registry.

> This plugin was built with the assistance of [Claude Code](https://claude.ai/code), Anthropic's AI coding assistant.

### What it does

Blocks incoming connections whose IP is listed in the [Data-Shield Critical IPv4 Blocklist](https://github.com/duggytuxy/Data-Shield_IPv4_Blocklist) (~100k IPs, updated every
6 hours). Uses Zoraxy's Dynamic Capture mode — every request is sniffed and blocked with a 403 if the client IP matches.

### Features

- ~100k IPs from the Data-Shield Critical list, auto-refreshed every 6 hours
- Sub-millisecond O(1) lookup via in-memory hash set
- Manual IP management (add/remove individual IPs via the UI)
- IPv6 and private/loopback ranges always pass through
- Live stats (IP count, blocked request count, last update time)

### Checklist

- [x] `.introspect` present in repo root
- [x] `.releaseurl` present in repo root
- [x] Pre-built binaries available for all standard platforms (linux/amd64, linux/386, linux/arm, linux/arm64, linux/mipsle, linux/riscv64, windows/amd64)
- [x] Plugin UI included
- [x] AGPL-3.0 license
