### PR TITLE
Add prometheus-exporter plugin

### DIFF
--- a/apps/prometheus-exporter.json
+++ b/apps/prometheus-exporter.json
@@ -1,0 +1,6 @@
+{
+    "repo_url": "https://github.com/reptil1990/zoraxy-prometheus-exporter",
+    "author": "reptil1990",
+    "contact": "reptil1990@me.com",
+    "min_zoraxy_version": "3.0.0"
+}


### PR DESCRIPTION
Adds the Prometheus Exporter plugin for Zoraxy.

Exports Zoraxy statistical analysis data (requests, network stats) as Prometheus metrics on a dedicated scrape endpoint.

- Repo: https://github.com/reptil1990/zoraxy-prometheus-exporter
- Plugin ID: `prometheus-exporter`
- `.introspect` and `.releaseurl` are present in the repo root