### PR TITLE
WIP: Added zoraxy-anubis-adapter

### DIFF
--- a/apps/com.sniffingsugar.zoraxy-anubis-adapter.json
+++ b/apps/com.sniffingsugar.zoraxy-anubis-adapter.json
@@ -1,0 +1,6 @@
+{
+  "repo_url": "https://github.com/sniffingsugar/zoraxy-anubis-adapter",
+  "author": "sniffingsugar",
+  "contact": "https://github.com/sniffingsugar",
+  "min_zoraxy_version": "3.2.0"
+}

--- a/directories/index2.json
+++ b/directories/index2.json
@@ -43,6 +43,49 @@
   }
  },
  {
+  "IconPath": "",
+  "PluginIntroSpect": {
+   "id": "com.sniffingsugar.zoraxy-anubis-adapter",
+   "name": "Anubis Bot Protection",
+   "author": "sniffingsugar",
+   "author_contact": "",
+   "description": "Forward-Auth adapter for Anubis AI crawler defense.",
+   "url": "https://github.com/sniffingsugar/zoraxy-anubis-adapter",
+   "type": 1,
+   "version_major": 0,
+   "version_minor": 1,
+   "version_patch": 3,
+   "static_capture_paths": null,
+   "static_capture_ingress": "",
+   "dynamic_capture_sniff": "",
+   "dynamic_capture_ingress": "",
+   "ui_path": "/ui",
+   "subscription_path": "",
+   "subscriptions_events": null,
+   "permitted_api_endpoints": [
+    {
+     "endpoint": "/api/proxy/list",
+     "method": "GET",
+     "reason": "List proxy rules"
+    },
+    {
+     "endpoint": "/api/proxy/vdir/list",
+     "method": "GET",
+     "reason": "List vdirs"
+    }
+   ]
+  },
+  "DownloadURLs": {
+   "linux_386": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_386",
+   "linux_amd64": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_amd64",
+   "linux_arm": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_arm",
+   "linux_arm64": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_arm64",
+   "linux_mipsle": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_mipsle",
+   "linux_riscv64": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_linux_riscv64",
+   "windows_amd64": "https://github.com/sniffingsugar/zoraxy-anubis-adapter/releases/latest/download/zoraxy-anubis-adapter_windows_amd64.exe"
+  }
+ },
+ {
   "IconPath": "https://raw.githubusercontent.com/kianby/zoraxy-datashield-blocklist/refs/heads/main/icon.png",
   "PluginIntroSpect": {
    "id": "fr.madyanne.zoraxy.datashield-blocklist",


### PR DESCRIPTION
## What it does

Anubis (https://github.com/techarohq/anubis) throws a proof-of-work challenge at ai crawlers and scrapers. real browsers solve it in under a second, bots can't. this plugin lets you use it with zoraxy without patching anything — it's a utilities plugin that bridges anubis into zoraxy's forward-auth system.

## How it works

When zoraxy gets a request on a protected route, it hits the plugin's /check endpoint via forward-auth. the plugin forwards that to anubis's /check in subrequest mode. anubis says 200 (human, let them through) or 401 (challenge needed).

On 401 the plugin responds with a 401 + location header pointing to /.within.website/ on the same host, that's important because it means the anubis cookie gets set for the right domain. zoraxy converts that 401+location into a 302 redirect and the browser loads the challenge page (served via a /.within.website/ vdir that proxies to anubis). once the browser solves the pow and gets the cookie, subsequent requests pass through normally.

The plugin ui lets you toggle which routes get protected. there's also a button to set up the global forward-auth config so you don't have to do it manually.

## requirements

- zoraxy 3.2.0+ (plugin system)
- anubis running separately in subrequest mode (target=" ")
- botpolicies.yaml needs status_codes: { deny: 403 }

Has .introspect, .releaseurl, and github actions building for linux (amd64/arm64/arm) and windows. the plugin id is com.sniffingsugar.zoraxy-anubis-adapter.

happy to adjust anything if needed.