### PR TITLE
Added Zoraxy Adapter

### DIFF
--- a/apps/com.sniffingsugar.zoraxy-anubis-adapter.json
+++ b/apps/com.sniffingsugar.zoraxy-anubis-adapter.json
@@ -1,0 +1,7 @@
+{
+  "repo_url": "https://github.com/sniffingsugar/zoraxy-anubis-adapter",
+  "author": "sniffingsugar",
+  "contact": "phil@hackmi.ch",
+  "min_zoraxy_version": "3.2.0"
+}
+


### PR DESCRIPTION
## What it does

Anubis (https://github.com/techarohq/anubis) throws a proof-of-work challenge at ai crawlers and scrapers. real browsers solve it in under a second, bots can't. this plugin lets you use it with zoraxy without patching anything. it's a utilities plugin that bridges anubis into zoraxy's forward-auth system.

## How it works

When zoraxy gets a request on a protected route, it hits the plugin's /check endpoint via forward-auth. the plugin forwards that to anubis's /check in subrequest mode. anubis says 200 (human, let them through) or 401 (challenge needed).

On 401 the plugin responds with a 401 + location header pointing to /.within.website/ on the same host, that's important because it means the anubis cookie gets set for the right domain. zoraxy converts that 401+location into a 302 redirect and the browser loads the challenge page (served via a /.within.website/ vdir that proxies to anubis). once the browser solves the pow and gets the cookie, subsequent requests pass through normally.

The plugin ui lets you toggle which routes get protected. there's also a button to set up the global forward-auth config so you don't have to do it manually.

## requirements

- zoraxy 3.2.0+ (plugin system)
- anubis running separately in subrequest mode (target=" ")
- botpolicies.yaml needs status_codes: { deny: 403 }

Has .introspect, .releaseurl, and github actions building for linux (amd64/arm64/arm) and windows. the plugin id is com.sniffingsugar.zoraxy-anubis-adapter.

happy to adjust anything if needed.