### PR TITLE
Added zoraxy-tunnel

### DIFF
--- a/apps/com.sniffingsugar.zoraxy-tunnel.json
+++ b/apps/com.sniffingsugar.zoraxy-tunnel.json
@@ -1,0 +1,7 @@
+{
+  "repo_url": "https://github.com/sniffingsugar/zoraxy-tunnel",
+  "author": "sniffingsugar",
+  "contact": "phil@hackmi.ch",
+  "min_zoraxy_version": "3.2.0"
+}
+


### PR DESCRIPTION
# Summary

This adds Zoraxy Tunnel, a self-hosted reverse tunnel server that runs as a native Zoraxy plugin. It gives Zoraxy a Cloudflare-Tunnel-style inbound tunnel: a lightweight client on any machine behind NAT or a firewall dials back into Zoraxy over TLS, and you expose that machine's local services to the public internet through Zoraxy's existing reverse proxy. No external account, no SaaS dependency, no third party in the traffic path.

## Motivation

Cloudflare Tunnel is convenient but routes traffic through a third party and requires an account. For homelab and self-hosted users who already run Zoraxy, there is no equivalent first-party option. This plugin fills that gap: the tunnel server lives inside Zoraxy, identity is pinned locally, and everything is managed from the Zoraxy UI.

## Architecture

The plugin is a single Go binary running three listeners, all sharing one config store and one session registry.

Control plane `:9443` (bound to `0.0.0.0`, public): the TLS endpoint tunnel clients dial.
Ingress `:9080` (bound to `127.0.0.1`, local): the public HTTP target Zoraxy routes into.
Dashboard UI `:<dynamic>` (bound to `127.0.0.1`, local): the plugin UI and JSON API, proxied by Zoraxy.

Only the control port is exposed to the internet. The ingress and UI are bound to loopback and reachable only from Zoraxy on the same host.


## Features

- Multiple tunnels, each with multiple registered services (public host plus optional path prefix, routed to a client-local target).
- Full HTTP method support including request bodies and streaming responses.
- WebSocket support, transparently bridged end to end.
- One-click route installation per service: the plugin creates the matching Zoraxy host proxy rule via `POST /api/proxy/add` pointing at the ingress port. Deleting a service or tunnel removes its route via `POST /api/proxy/del`. The required endpoints are declared in `PermittedAPIEndpoints`.
- Dashboard shows the fingerprint, a ready-to-copy `tunnel-client` command, plus `docker run` and `docker-compose.yml` variants with per-platform download links.
- The client reconnects automatically with exponential backoff, resets to a fast retry after an authenticated session drops, and bounds both TCP connect and TLS handshake to 10 seconds so unreachable targets and network failures surface quickly instead of hanging.


## Screenshot from the UI
<img width="1064" height="629" alt="Bildschirmfoto 2026-08-01 um 10" src="https://github.com/user-attachments/assets/1e99215e-4558-4609-a30f-ebff4ef6a68f" />
