### PR TITLE
Add FQDN Whitelist Sync

### DIFF
--- a/apps/io.github.driin0.zoraxy.fqdn_whitelist_sync.json
+++ b/apps/io.github.driin0.zoraxy.fqdn_whitelist_sync.json
@@ -1,0 +1,6 @@
+{
+  "repo_url": "https://github.com/driin0/zoraxy-fqdn-whitelist-sync",
+  "author": "driin0",
+  "contact": "driin0@users.noreply.github.com",
+  "min_zoraxy_version": "3.3.3"
+}


### PR DESCRIPTION
Adds an entry for FQDN Whitelist Sync, a utility plugin that keeps a Zoraxy access-control whitelist in sync with the IPs a set of FQDNs resolves to — intended for allowing access from sites on dynamic residential addresses via DDNS names.

It fails closed (a name that stops resolving loses its authorisation), only touches entries it tagged itself with `fqdn-sync:<fqdn>`, and never authorises unroutable sentinel addresses such as the `192.0.2.1` a DDNS provider publishes for an offline device.

Repository: https://github.com/driin0/zoraxy-fqdn-whitelist-sync
Release: https://github.com/driin0/zoraxy-fqdn-whitelist-sync/releases/tag/v1.1.1

The repository root carries `.introspect`, `.releaseurl` and `icon.png`. Ran `tools/dirupdate2` locally against this entry: the introspect and icon are picked up, and all seven download URLs it composes return HTTP 200. Only `apps/` is included here — `directories/index2.json` is left for regeneration.

Verified against Zoraxy v3.3.3 and v3.3.4-rc2: plugin discovery, first start with no config file, UI and icon, a full sync cycle against the live plugin API, and a clean shutdown. Binaries are published for all seven platforms the indexer resolves.