### PR TITLE
Add Cloudflare Tunnel plugin

### DIFF
--- a/apps/com.fcannizzaro.zoraxy-cloudflare-tunnel.json
+++ b/apps/com.fcannizzaro.zoraxy-cloudflare-tunnel.json
@@ -1,0 +1,15 @@
+{
+  "repo_url": "https://github.com/fcannizzaro/zoraxy-cloudflare-tunnel",
+  "author": "Francesco Saverio Cannizzaro",
+  "contact": "https://github.com/fcannizzaro",
+  "min_zoraxy_version": "3.2.0",
+  "artifact_names": {
+    "linux_amd64": "cloudflare-tunnel_linux_amd64",
+    "linux_arm64": "cloudflare-tunnel_linux_arm64",
+    "linux_arm": "cloudflare-tunnel_linux_arm",
+    "windows_amd64": "cloudflare-tunnel_windows_amd64.exe",
+    "windows_arm64": "cloudflare-tunnel_windows_arm64.exe",
+    "darwin_amd64": "cloudflare-tunnel_darwin_amd64",
+    "darwin_arm64": "cloudflare-tunnel_darwin_arm64"
+  }
+}

--- a/apps/com.fcannizzaro.zoraxy-cloudflare-tunnel.json
+++ b/apps/com.fcannizzaro.zoraxy-cloudflare-tunnel.json
@@ -2,14 +2,5 @@
   "repo_url": "https://github.com/fcannizzaro/zoraxy-cloudflare-tunnel",
   "author": "Francesco Saverio Cannizzaro",
   "contact": "https://github.com/fcannizzaro",
-  "min_zoraxy_version": "3.2.0",
-  "artifact_names": {
-    "linux_amd64": "cloudflare-tunnel_linux_amd64",
-    "linux_arm64": "cloudflare-tunnel_linux_arm64",
-    "linux_arm": "cloudflare-tunnel_linux_arm",
-    "windows_amd64": "cloudflare-tunnel_windows_amd64.exe",
-    "windows_arm64": "cloudflare-tunnel_windows_arm64.exe",
-    "darwin_amd64": "cloudflare-tunnel_darwin_amd64",
-    "darwin_arm64": "cloudflare-tunnel_darwin_arm64"
-  }
+  "min_zoraxy_version": "3.2.0"
 }


### PR DESCRIPTION
## Add Cloudflare Tunnel plugin

### Summary

This PR adds **Cloudflare Tunnel** to the Zoraxy official plugin registry.

The plugin provides integration between Zoraxy and Cloudflare Tunnel, allowing users to configure Cloudflare Tunnel public hostnames and expose them through Zoraxy.

### Plugin information

* **Plugin:** Cloudflare Tunnel
* **Plugin ID:** `com.fcannizzaro.zoraxy-cloudflare-tunnel`
* **Repository:** https://github.com/fcannizzaro/zoraxy-cloudflare-tunnel
* **Author:** `Francesco Saverio Cannizzaro`
* **Author contact:** GitHub `@fcannizzaro`
* **Current version:** `1.0.4`

### Repository requirements

Confirmed that the remote plugin repository contains the required plugin metadata at the repository root:

* [x] `.introspect`
* [x] `.releaseurl`
* [x] `icon.png`